### PR TITLE
Follow redirects to actually measure time spent on redirects

### DIFF
--- a/curl-timing.sh
+++ b/curl-timing.sh
@@ -12,4 +12,4 @@ format="
                             ----------
                  time_total:  %{time_total}\n\n"
 
-curl -w "$format" -o /dev/null -s $1
+curl -L -w "$format" -o /dev/null -s $1


### PR DESCRIPTION
Follow redirects to actually measure time spent on redirects in `curl-timing.sh`

Before:

```
$ ./curl-timing.sh github.com

            time_namelookup:  0.072069
               time_connect:  0.105618
            time_appconnect:  0.000000
           time_pretransfer:  0.105739
              time_redirect:  0.000000
         time_starttransfer:  0.132125
                            ----------
                 time_total:  0.132207

```

After:

```
$ ./curl-timing.sh github.com

            time_namelookup:  0.108762
               time_connect:  0.160227
            time_appconnect:  0.121475
           time_pretransfer:  0.201877
              time_redirect:  0.111456
         time_starttransfer:  0.269174
                            ----------
                 time_total:  0.508880
```